### PR TITLE
Sometimes access_token is not the first argument

### DIFF
--- a/openidconnect.js
+++ b/openidconnect.js
@@ -897,7 +897,7 @@ OIDC.getAccessToken = function()
     try {
       var url = window.location.href;
       // Check for token
-      var token = url.match('[?#]access_token=([^&]*)');
+      var token = url.match('[?#&]access_token=([^&]*)');
       if (token)
         return token[1];
       else


### PR DESCRIPTION
So, in my case the hash-ref looks like  `#state=zt50o1&access_token=ya29...`