### PR TITLE
Support authenticating in a pop-up window

### DIFF
--- a/openidconnect.js
+++ b/openidconnect.js
@@ -714,6 +714,8 @@ OIDC.login = function(reqOptions) {
     + '&state=' + state
     + optParams;
 
+    if (reqOptions['window'])
+      return window.open(url, '_blank', reqOptions['window']);
     window.location.replace(url);
   } catch (e) {
       throw new OidcException('Unable to redirect to the Identity Provider for authenticaton: ' + e.toString());


### PR DESCRIPTION
For some use cases, notably responsive SPAs, it might be useful to have the authentication and callback workflow handled in a pop-up window instead of exiting the application to handle the redirection and call back.

For example use case, see the feature in use in a [Web Component implementation for Polymer, here](https://github.com/GreenfieldTech/oidc-login/commit/e0a07240c1d8c34927dbf99e2475e0d5a9482667). The callback implementation in the example is... ehm... "interesting", but a simpler implementation would work just as well (just doing `window.close()` after updated `window.localStorage` will likely suffice for most use cases).